### PR TITLE
Add libsss-sudo library

### DIFF
--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -6,5 +6,6 @@ sssd_ldap_packages:
   - openssh-server
   - libnss-sss
   - libpam-sss
+  - libsss-sudo
 
 sssd_ldap_ssh_service: ssh


### PR DESCRIPTION
needed to prevent the following error:
```
sudo: unable to load /usr/lib/x86_64-linux-gnu/libsss_sudo.so: (null)
sudo: unable to initialize SSS source. Is SSSD installed on your machine?
```